### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -23,10 +23,10 @@ jobs:
       PYPI_UPLOAD: true  # true or false
       TESTPYPI_UPLOAD: false
       CIBW_BUILD: ${{ matrix.python }}-*
-      CIBW_ARCHS_LINUX: "x86_64"
+      CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       # No support for pypy, musl, Win32 for 3.10+
-      CIBW_SKIP: "pp* *-musllinux_x86_64 cp310-win32"
+      CIBW_SKIP: "pp* *-musllinux_x86_64 cp310-win32 *-musllinux_aarch64"
       CIBW_TEST_REQUIRES: pytest pytest-xdist
       CIBW_TEST_COMMAND: python -c "import arch; arch.test(['-n','2','--skip-slow'])"
       CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'auditwheel repair --strip -w {dest_dir} {wheel}'
@@ -44,6 +44,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+
+      - uses: docker/setup-qemu-action@v1
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        name: Set up QEMU
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.3.1


### PR DESCRIPTION
Add linux aarch64 wheel build support. 

Related to https://github.com/bashtage/arch-wheels/issues/4 @bashtage Could you please review this PR?